### PR TITLE
Replace deprecated `np.find_common_type` calls with `np.promote_types`

### DIFF
--- a/src/pyfma/_main.py
+++ b/src/pyfma/_main.py
@@ -2,12 +2,13 @@ import _pyfma
 import numpy as np
 from numpy.typing import ArrayLike
 
+p = np.promote_types
 
 def fma(a: ArrayLike, b: ArrayLike, c: ArrayLike) -> np.ndarray:
     a = np.asarray(a)
     b = np.asarray(b)
     c = np.asarray(c)
-    dtype = np.find_common_type([], [a.dtype, b.dtype, c.dtype])
+    dtype = p(p(a.dtype, b.dtype), c.dtype)
     a = a.astype(dtype)
     b = b.astype(dtype)
     c = c.astype(dtype)


### PR DESCRIPTION
Closes #16 

## Overview
* Replaces calls to [`np.find_common_type`](https://numpy.org/doc/1.25/reference/generated/numpy.find_common_type.html), which was deprecated in NumPy 2.0 with calls to [`np.promote_types`](https://numpy.org/doc/1.25/reference/generated/numpy.promote_types.html#numpy.promote_types)